### PR TITLE
Fix documentation, renamed method getParent to a less conflictual name getInheritedParent

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ $admin->parent->doSomething()   //User does something
 This trait is very useful for faking inheritance, however query filters should be applied on the parent relation.
 ```php
 $admin = Admin::find()
-    ->joinWith('parent', function($query) {
+    ->joinWith(['parent' => function($query) {
         $query->andWhere(['username' => 'al-acran']);
         $query->andWhere(['name' => 'Al']);
-    })
+    }])
     ->andWhere(['level' => 1])
     ->one();
 ```

--- a/src/ActiveRecordInheritanceTrait.php
+++ b/src/ActiveRecordInheritanceTrait.php
@@ -386,7 +386,7 @@ trait ActiveRecordInheritanceTrait {
      * 
      * @return \yii\db\ActiveQueryInterface
      */
-    public function getParent() {
+    public function getInheritedParent() {
         $class = static::extendsFrom();
         return $this->hasOne($class::className(), [$this->parentPrimaryKey() => $this->parentAttribute()]);
     }


### PR DESCRIPTION
…equery.html#joinWith%28%29-detail
1. Change getParent method name to getInheritedParent(it could be a problem, if in my model i already have relation to model Parent)
